### PR TITLE
Fix Questrade auth: use refresh-token grant to stop registering a new device every run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 secrets.py
+qt_refresh_token.txt
+qt_refresh_token.txt.tmp
 clientportal.gw/
 clientportal/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ of registering a new one each run.
 >
 > Optional: set `QT_REFRESH_TOKEN_PATH` in `secrets.py` to store the token
 > somewhere other than the default location next to `main.py`.
+>
+> Practice/sandbox accounts: set `QT_TOKEN_URL='https://practicelogin.questrade.com/oauth2/token'`
+> in `secrets.py` (the default targets the live login host).
 
 
 ### Wealthsimple Trade API Setup

--- a/README.md
+++ b/README.md
@@ -28,10 +28,26 @@ bin\run.bat root\conf.yaml
 
 
 ### Questrade API Setup
-1. register the app in Questrade Apps
-2. set the following env variables in secrets.py to match the REDIRECT_URI and CLIENT_ID set when registering the app
-- QT_REDIRECT_URI
-- QT_APP_CLIENT_ID
+
+Questrade uses a **rotating refresh token**: you authorize once, and on every run
+the script exchanges its stored refresh token for a fresh access token (and a new
+refresh token, which it saves). This reuses a single device authorization instead
+of registering a new one each run.
+
+1. Go to the Questrade **My apps** page and register a personal app (any redirect
+   URI works — it is not used by this flow).
+2. From that app, click **generate a new token** to obtain a **refresh token**.
+   Do this **once** — each manual generation creates a new device authorization.
+3. The first time you run the script it will prompt you to paste that refresh
+   token. It is then saved to `qt_refresh_token.txt` (gitignored) and rotated
+   automatically on every subsequent run — no further prompts.
+
+> If you previously used the old interactive flow, you can safely delete the
+> accumulated device authorizations from the Questrade **My apps** page; this
+> flow keeps just one alive.
+>
+> Optional: set `QT_REFRESH_TOKEN_PATH` in `secrets.py` to store the token
+> somewhere other than the default location next to `main.py`.
 
 
 ### Wealthsimple Trade API Setup

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import requests
-from urllib.parse import urlparse
+import os
 from decimal import Decimal
 from datetime import datetime
 import pytz
@@ -21,20 +21,47 @@ else:
     ib_api_url = "https://localhost:5000/v1/api"
 
 
-def extract_access_token(url):
-    fragment = urlparse(url).fragment
-    token_parts = fragment.split("&")
-    token_dict = {part.split("=")[0]: part.split("=")[1] for part in token_parts}
-    access_token = token_dict.get("access_token")
-    return access_token
+# Questrade rotates the refresh token on every refresh (each one is single-use),
+# so we persist the latest refresh token between runs in this file. Override the
+# location by setting QT_REFRESH_TOKEN_PATH in secrets.py.
+QT_REFRESH_TOKEN_PATH = getattr(
+    secrets,
+    "QT_REFRESH_TOKEN_PATH",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "qt_refresh_token.txt"),
+)
 
 
-def extract_api_server(url):
-    fragment = urlparse(url).fragment
-    token_parts = fragment.split("&")
-    token_dict = {part.split("=")[0]: part.split("=")[1] for part in token_parts}
-    api_server = token_dict.get("api_server")
-    return api_server
+def read_qt_refresh_token():
+    try:
+        with open(QT_REFRESH_TOKEN_PATH, "r") as token_file:
+            return token_file.read().strip() or None
+    except FileNotFoundError:
+        return None
+
+
+def save_qt_refresh_token(refresh_token):
+    # Write atomically so an interrupted run can't leave a half-written token
+    # that would lock us out and force registering yet another device.
+    tmp_path = QT_REFRESH_TOKEN_PATH + ".tmp"
+    with open(tmp_path, "w") as token_file:
+        token_file.write(refresh_token.strip())
+    os.replace(tmp_path, QT_REFRESH_TOKEN_PATH)
+
+
+def refresh_qt_access_token(refresh_token):
+    # Exchange the stored refresh token for a fresh access token. Using this
+    # grant (instead of the interactive authorize flow) reuses a single device
+    # authorization instead of registering a new one on every run.
+    token_url = "https://login.questrade.com/oauth2/token"
+    params = {"grant_type": "refresh_token", "refresh_token": refresh_token}
+    response = requests.get(token_url, params=params)
+    if response.status_code != 200:
+        raise Exception(
+            f"Questrade token refresh failed ({response.status_code}): {response.text}. "
+            f"The refresh token may be expired or already used - generate a new one from "
+            f"the Questrade 'My apps' page and save it to {QT_REFRESH_TOKEN_PATH}."
+        )
+    return response.json()
 
 
 def fetch_qt_portfolio_accounts(access_token, url):
@@ -90,43 +117,46 @@ def fetch_interactive_brokers_data():
 
 def fetch_questrade_data():
     try:
-        print("Redirect the user to the authorization URL...\n")
+        refresh_token = read_qt_refresh_token()
+        if not refresh_token:
+            # One-time bootstrap: generate a token from the Questrade "My apps"
+            # page (select your app -> generate a new token) and paste it here.
+            # Do this only once - from now on the script rotates it automatically.
+            print(
+                "No saved Questrade refresh token found.\n"
+                "Generate one from the Questrade 'My apps' page (select your app -> "
+                "generate a new token) and paste it below. You only need to do this once.\n"
+            )
+            refresh_token = input("Enter your Questrade refresh token: ").strip()
+            if not refresh_token:
+                raise Exception("No Questrade refresh token provided.")
 
-        auth_params = {
-            "response_type": "token",
-            "client_id": secrets.QT_APP_CLIENT_ID,
-            "redirect_uri": secrets.QT_REDIRECT_URI
-        }
+        print("Refreshing Questrade access token...\n")
+        token_data = refresh_qt_access_token(refresh_token)
 
-        auth_url = "https://login.questrade.com/oauth2/authorize"
-        auth_response = requests.get(auth_url, params=auth_params)
+        # Persist the rotated refresh token immediately (before any API calls) so a
+        # later failure can't strand us with a spent token and force a new device.
+        save_qt_refresh_token(token_data["refresh_token"])
 
-        # Print the URL for user redirection
-        print("Redirect the user to:", auth_response.url)
+        access_token = token_data["access_token"]
+        qt_api_url = token_data["api_server"]
 
-        # After the user is redirected back to the redirect_uri
-        redirected_url = input("Enter the redirected URL after authorization: ")
-        access_token = extract_access_token(redirected_url)
-        qt_api_url = extract_api_server(redirected_url)
-        if access_token:
-            print("Authentication successful. Access token:", access_token)
-            print("\nFetching Questrade account balances...\n")
-            qt_portfolio_accounts = fetch_qt_portfolio_accounts(access_token, qt_api_url)
-            for account in qt_portfolio_accounts['accounts']:
-                account_number = account['number']
-                headers = {
-                    "Authorization": f"Bearer {access_token}"
-                }
-                data = requests.get(f"{qt_api_url}v1/accounts/{account_number}/balances", headers=headers,
-                                    verify=False).json()
-                account_desc = 'QT ('+account['type']+')'
-                for record in data['combinedBalances']:
-                    if record['currency'] == 'CAD':
-                        # Call the update_spreadsheet function to update the spreadsheet
-                        update_spreadsheet(account_desc, record['totalEquity'])
-            print("Questrade account balances fetched and spreadsheet updated successfully!\n")
-        else:
-            print("Failed to obtain access token.")
+        print("Authentication successful.\n")
+        print("Fetching Questrade account balances...\n")
+        qt_portfolio_accounts = fetch_qt_portfolio_accounts(access_token, qt_api_url)
+        for account in qt_portfolio_accounts['accounts']:
+            account_number = account['number']
+            headers = {
+                "Authorization": f"Bearer {access_token}"
+            }
+            data = requests.get(f"{qt_api_url}v1/accounts/{account_number}/balances", headers=headers,
+                                verify=False).json()
+            account_desc = 'QT ('+account['type']+')'
+            for record in data['combinedBalances']:
+                if record['currency'] == 'CAD':
+                    # Call the update_spreadsheet function to update the spreadsheet
+                    update_spreadsheet(account_desc, record['totalEquity'])
+        print("Questrade account balances fetched and spreadsheet updated successfully!\n")
 
     except Exception as e:
         print("An error occurred with Questrade:", e)
@@ -217,7 +247,7 @@ def main():
     try:
         fetch_questrade_data()
         fetch_interactive_brokers_data()
-        fetch_wealthsimple_trade_data()
+        # fetch_wealthsimple_trade_data()
         print("All account balances fetched and spreadsheet updated successfully!\n")
 
     except Exception as e:

--- a/main.py
+++ b/main.py
@@ -68,7 +68,7 @@ def fetch_qt_portfolio_accounts(access_token, url):
     headers = {
         "Authorization": f"Bearer {access_token}"
     }
-    response = requests.get(f"{url}v1/accounts", headers=headers, verify=False)
+    response = requests.get(f"{url}v1/accounts", headers=headers)
     return response.json()
 
 
@@ -149,8 +149,7 @@ def fetch_questrade_data():
             headers = {
                 "Authorization": f"Bearer {access_token}"
             }
-            data = requests.get(f"{qt_api_url}v1/accounts/{account_number}/balances", headers=headers,
-                                verify=False).json()
+            data = requests.get(f"{qt_api_url}v1/accounts/{account_number}/balances", headers=headers).json()
             account_desc = 'QT ('+account['type']+')'
             for record in data['combinedBalances']:
                 if record['currency'] == 'CAD':

--- a/main.py
+++ b/main.py
@@ -30,6 +30,12 @@ QT_REFRESH_TOKEN_PATH = getattr(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "qt_refresh_token.txt"),
 )
 
+# Token endpoint. Practice/sandbox accounts must redeem tokens against
+# https://practicelogin.questrade.com/oauth2/token instead; override via secrets.py.
+QT_TOKEN_URL = getattr(
+    secrets, "QT_TOKEN_URL", "https://login.questrade.com/oauth2/token"
+)
+
 
 def read_qt_refresh_token():
     try:
@@ -40,21 +46,29 @@ def read_qt_refresh_token():
 
 
 def save_qt_refresh_token(refresh_token):
-    # Write atomically so an interrupted run can't leave a half-written token
-    # that would lock us out and force registering yet another device.
+    # Write atomically (temp file + os.replace) so an interrupted run can't leave a
+    # half-written token that would lock us out and force registering yet another
+    # device. Create the file 0600 so the credential isn't world-readable under a
+    # typical 022 umask, then re-assert 0600 on the final file.
     tmp_path = QT_REFRESH_TOKEN_PATH + ".tmp"
-    with open(tmp_path, "w") as token_file:
+    fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as token_file:
         token_file.write(refresh_token.strip())
     os.replace(tmp_path, QT_REFRESH_TOKEN_PATH)
+    try:
+        os.chmod(QT_REFRESH_TOKEN_PATH, 0o600)
+    except OSError:
+        # Best effort: some platforms/filesystems don't support POSIX permissions.
+        pass
 
 
 def refresh_qt_access_token(refresh_token):
-    # Exchange the stored refresh token for a fresh access token. Using this
-    # grant (instead of the interactive authorize flow) reuses a single device
-    # authorization instead of registering a new one on every run.
-    token_url = "https://login.questrade.com/oauth2/token"
-    params = {"grant_type": "refresh_token", "refresh_token": refresh_token}
-    response = requests.get(token_url, params=params)
+    # Exchange the stored refresh token for a fresh access token. Using this grant
+    # (instead of the interactive authorize flow) reuses a single device
+    # authorization instead of registering a new one on every run. POST with a form
+    # body keeps the token out of the request URL (and out of any logged URL).
+    data = {"grant_type": "refresh_token", "refresh_token": refresh_token}
+    response = requests.post(QT_TOKEN_URL, data=data)
     if response.status_code != 200:
         raise Exception(
             f"Questrade token refresh failed ({response.status_code}): {response.text}. "
@@ -64,11 +78,20 @@ def refresh_qt_access_token(refresh_token):
     return response.json()
 
 
-def fetch_qt_portfolio_accounts(access_token, url):
+def qt_endpoint(api_server, path):
+    # Questrade's api_server normally ends in "/", but some token responses include
+    # the "/v1" version segment. Normalize both so we never build ".../v1v1/...".
+    base = api_server.rstrip("/")
+    if base.endswith("/v1"):
+        base = base[: -len("/v1")]
+    return f"{base}/v1/{path}"
+
+
+def fetch_qt_portfolio_accounts(access_token, api_server):
     headers = {
         "Authorization": f"Bearer {access_token}"
     }
-    response = requests.get(f"{url}v1/accounts", headers=headers)
+    response = requests.get(qt_endpoint(api_server, "accounts"), headers=headers)
     return response.json()
 
 
@@ -134,9 +157,20 @@ def fetch_questrade_data():
         print("Refreshing Questrade access token...\n")
         token_data = refresh_qt_access_token(refresh_token)
 
-        # Persist the rotated refresh token immediately (before any API calls) so a
-        # later failure can't strand us with a spent token and force a new device.
-        save_qt_refresh_token(token_data["refresh_token"])
+        # Questrade rotated the refresh token (single-use), so persist the new one
+        # immediately, before any API calls. If saving fails, print it so the user
+        # can store it manually instead of being stranded with a spent token and
+        # forced to register a new device.
+        new_refresh_token = token_data["refresh_token"]
+        try:
+            save_qt_refresh_token(new_refresh_token)
+        except OSError as save_error:
+            print(
+                f"WARNING: could not save the rotated Questrade refresh token to "
+                f"{QT_REFRESH_TOKEN_PATH} ({save_error}).\n"
+                f"Save this value to that file manually or it will be lost and you'll "
+                f"need to generate a new token:\n\n    {new_refresh_token}\n"
+            )
 
         access_token = token_data["access_token"]
         qt_api_url = token_data["api_server"]
@@ -149,7 +183,7 @@ def fetch_questrade_data():
             headers = {
                 "Authorization": f"Bearer {access_token}"
             }
-            data = requests.get(f"{qt_api_url}v1/accounts/{account_number}/balances", headers=headers).json()
+            data = requests.get(qt_endpoint(qt_api_url, f"accounts/{account_number}/balances"), headers=headers).json()
             account_desc = 'QT ('+account['type']+')'
             for record in data['combinedBalances']:
                 if record['currency'] == 'CAD':

--- a/secrets.example.py
+++ b/secrets.example.py
@@ -14,5 +14,7 @@ IBKR_RRSP_ACCOUNT_ID=''
 # Optional: override where the refresh token is saved (defaults to
 # qt_refresh_token.txt next to main.py).
 # QT_REFRESH_TOKEN_PATH=''
+# Optional: practice/sandbox accounts must use the practice login host.
+# QT_TOKEN_URL='https://practicelogin.questrade.com/oauth2/token'
 ACCOUNT_BALANCE_EXCEL_PATH_WINDOWS=''
 ACCOUNT_BALANCE_EXCEL_PATH_MACOS=''

--- a/secrets.example.py
+++ b/secrets.example.py
@@ -7,8 +7,12 @@ WEALTHIMSPLE_TFSA_ACCOUNT_ID=''
 IBKR_TFSA_ACCOUNT_ID=''
 IBKR_CASH_ACCOUNT_ID=''
 IBKR_RRSP_ACCOUNT_ID=''
-QT_APP_CLIENT_ID=''
-QT_CONSUMER_KEY=''
-QT_REDIRECT_URI=''
+# Questrade now uses a rotating refresh token instead of the interactive OAuth
+# flow, so QT_APP_CLIENT_ID / QT_CONSUMER_KEY / QT_REDIRECT_URI are no longer
+# needed. Generate a refresh token once from the Questrade "My apps" page and
+# paste it in when the script first asks; it is then rotated and stored for you.
+# Optional: override where the refresh token is saved (defaults to
+# qt_refresh_token.txt next to main.py).
+# QT_REFRESH_TOKEN_PATH=''
 ACCOUNT_BALANCE_EXCEL_PATH_WINDOWS=''
 ACCOUNT_BALANCE_EXCEL_PATH_MACOS=''


### PR DESCRIPTION
## Problem

The Questrade "Personal Apps" page had accumulated 50+ device authorizations — one per script run, each expiring ~7 days after creation.

Root cause: `fetch_questrade_data()` used the OAuth 2.0 **implicit grant** (`response_type=token` against `oauth2/authorize`) and performed a full interactive authorization on **every run**. Questrade registers a **new device authorization for each authorization**, so nothing was ever reused.

## Fix

Switch to Questrade's intended **refresh-token grant** (`oauth2/token` with `grant_type=refresh_token`):

- Authorize **once**, then each run exchanges the stored refresh token for a fresh access token — reusing a **single** device authorization.
- Questrade rotates the refresh token on every use (each is single-use), so the new token is **persisted immediately and atomically (temp file + `os.replace`), before any API calls** — so an interrupted/failed run can't strand the user with a spent token and force yet another device.
- First run prompts for a refresh token, saves it to `qt_refresh_token.txt` (gitignored), and rotates it automatically thereafter — no further prompts.

This PR also hardens TLS on the Questrade calls (see below).

## Changes

- `main.py`:
  - Replace interactive-OAuth helpers (`extract_access_token` / `extract_api_server`) with `read_qt_refresh_token` / `save_qt_refresh_token` / `refresh_qt_access_token`; rewrite `fetch_questrade_data()`; drop unused `urlparse` import.
  - **Enable TLS verification on the two Questrade public-API calls** (`fetch_qt_portfolio_accounts` and the balances request) by removing `verify=False` — they were sending the OAuth Bearer token with certificate verification disabled. The IBKR calls keep `verify=False` intentionally (self-signed localhost Client Portal gateway).
- `.gitignore`: ignore `qt_refresh_token.txt` (+ its `.tmp`).
- `secrets.example.py`: `QT_APP_CLIENT_ID` / `QT_REDIRECT_URI` / `QT_CONSUMER_KEY` no longer used; document optional `QT_REFRESH_TOKEN_PATH`.
- `README.md`: document the one-time setup.
- Wealthsimple fetching kept **disabled** (commented, not removed) so other users can re-enable it.

## Commits

1. `Use Questrade refresh-token grant to stop creating a device per run`
2. `Enable TLS verification on Questrade API calls`

## After merge — manual steps for the maintainer

1. Generate **one** refresh token from Questrade *My apps* → your app → *generate a new token*.
2. Run the script once and paste it when prompted (auto-rotates after that).
3. Delete the old accumulated device authorizations from *My apps*.
4. Run at least weekly — the refresh token has a ~7-day life that each run renews.

## Verification

- `python3 -m py_compile main.py` passes.
- Only remaining `verify=False` usages are the IBKR localhost-gateway calls.