### PR TITLE
Re-enable Wealthsimple by default, gate it behind ENABLE_WEALTHSIMPLE flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ of registering a new one each run.
 - WEALTHIMSPLE_RRSP_ACCOUNT_ID
 - WEALTHIMSPLE_TFSA_ACCOUNT_ID
 
+Wealthsimple fetching is **enabled by default**. If you don't use Wealthsimple,
+set `ENABLE_WEALTHSIMPLE = False` in your `secrets.py` to skip it on that machine
+(no need to touch `main.py` or maintain a separate branch).
+
 ### This is an example of the spreadsheet i'm updating with this script
 
 - Column A is the Account_Name

--- a/main.py
+++ b/main.py
@@ -36,6 +36,10 @@ QT_TOKEN_URL = getattr(
     secrets, "QT_TOKEN_URL", "https://login.questrade.com/oauth2/token"
 )
 
+# Wealthsimple fetching is on by default. Set ENABLE_WEALTHSIMPLE = False in
+# secrets.py to skip it on a specific machine (e.g. one without WS accounts).
+ENABLE_WEALTHSIMPLE = getattr(secrets, "ENABLE_WEALTHSIMPLE", True)
+
 
 def read_qt_refresh_token():
     try:
@@ -280,7 +284,10 @@ def main():
     try:
         fetch_questrade_data()
         fetch_interactive_brokers_data()
-        # fetch_wealthsimple_trade_data()
+        if ENABLE_WEALTHSIMPLE:
+            fetch_wealthsimple_trade_data()
+        else:
+            print("Wealthsimple fetching is disabled (ENABLE_WEALTHSIMPLE = False); skipping.\n")
         print("All account balances fetched and spreadsheet updated successfully!\n")
 
     except Exception as e:

--- a/secrets.example.py
+++ b/secrets.example.py
@@ -4,6 +4,9 @@ WEALTHSIMPLE_USERNAME=''
 WEALTHSIMPLE_PASSWORD=''
 WEALTHIMSPLE_RRSP_ACCOUNT_ID=''
 WEALTHIMSPLE_TFSA_ACCOUNT_ID=''
+# Wealthsimple fetching is enabled by default. Uncomment the line below to skip
+# it on this machine (e.g. if you don't have Wealthsimple accounts configured).
+# ENABLE_WEALTHSIMPLE = False
 IBKR_TFSA_ACCOUNT_ID=''
 IBKR_CASH_ACCOUNT_ID=''
 IBKR_RRSP_ACCOUNT_ID=''


### PR DESCRIPTION
## Problem

PR #2 unintentionally carried a commented-out `fetch_wealthsimple_trade_data()` call into `master`. As a result, **everyone who pulls the repo now has Wealthsimple fetching silently disabled** — `main()` skips both WS accounts while still printing "All account balances fetched... successfully". Disabling WS was only ever meant for the maintainer's own machine, not the shared default.

## Fix

Restore Wealthsimple as the default and make opting out a **per-machine config choice** instead of a code edit:

- `main()` calls `fetch_wealthsimple_trade_data()` again, guarded by `ENABLE_WEALTHSIMPLE`.
- `ENABLE_WEALTHSIMPLE = getattr(secrets, "ENABLE_WEALTHSIMPLE", True)` — defaults to **on**, so existing users (whose `secrets.py` doesn't define it) get Wealthsimple enabled automatically.
- To disable it on a specific machine, set `ENABLE_WEALTHSIMPLE = False` in that machine's (gitignored) `secrets.py`. No branch to maintain, no `main.py` edit.
- When disabled, it prints an explicit "skipping" line rather than silently doing nothing (addresses the silent-skip concern from the PR #2 review).

## Changes

- `main.py`: add `ENABLE_WEALTHSIMPLE` toggle; re-enable the guarded call in `main()`.
- `secrets.example.py`: document the opt-out flag.
- `README.md`: document that WS is on by default and how to skip it per machine.

## Why a flag instead of a branch

A long-lived personal branch with one line different would need rebasing onto `master` on every pull and a force-push to maintain. A gitignored config flag keeps `master` correct for everyone, requires zero ongoing maintenance, and never leaks a personal preference into anyone else's clone.

## Verification

- `python3 -m py_compile main.py` passes.