### PR TITLE
docs: document secrets.py setup and run steps, fix IBKR numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Python script that updates account balances utilizing APIs from various stock br
 # How To Run
 
 1. Clone this repository
+2. Copy `secrets.example.py` to `secrets.py` and fill in your own credentials. `secrets.py` is gitignored, so your credentials stay local. Each brokerage's required variables are listed in the sections below; optional settings (`ENABLE_WEALTHSIMPLE`, `QT_TOKEN_URL`, `QT_REFRESH_TOKEN_PATH`) are documented in `secrets.example.py`.
 
 
 ### Interactive Brokers API Setup
@@ -12,19 +13,19 @@ Python script that updates account balances utilizing APIs from various stock br
 - IBKR_CASH_ACCOUNT_ID
 - IBKR_RRSP_ACCOUNT_ID
 2. Download the [Interactive Brokers Client Portal Gateway](https://download2.interactivebrokers.com/portal/clientportal.gw.zip)
-3. Install Java [Java Download](https://www.java.com/download/ie_manual.jsp) 
-3. Extract the clientportal.gw.zip into the root of the UpdateBalanceSheet directory
-4. In the root of the UpdateBalanceSheet directory, create a python virtual environment venv and activate it
+3. Install Java [Java Download](https://www.java.com/download/ie_manual.jsp)
+4. Extract the clientportal.gw.zip into the root of the UpdateBalanceSheet directory
+5. In the root of the UpdateBalanceSheet directory, create a python virtual environment venv and activate it
 ```
 python -m venv venv
 .\venv\Scripts\activate.ps1
 pip install -r requirements.txt
 ```
-5. run the following command from the clientportal.gw inside prompt/terminal of your choice (CMD, PowerShell):
+6. run the following command from the clientportal.gw inside prompt/terminal of your choice (CMD, PowerShell):
 ```
 bin\run.bat root\conf.yaml
 ```
-6. Open https://localhost:5000 to login to your Interactive Brokers account Authorization the gateway proxy with your account credentials
+7. Open https://localhost:5000 to login to your Interactive Brokers account Authorization the gateway proxy with your account credentials
 
 
 ### Questrade API Setup
@@ -64,6 +65,16 @@ of registering a new one each run.
 Wealthsimple fetching is **enabled by default**. If you don't use Wealthsimple,
 set `ENABLE_WEALTHSIMPLE = False` in your `secrets.py` to skip it on that machine
 (no need to touch `main.py` or maintain a separate branch).
+
+### Running the script
+
+With the brokerage setup above complete:
+
+- **macOS:** run `./update_balance_sheet.sh` — it opens the IB Client Portal gateway in a new terminal, waits for you to log in at https://localhost:5001, then runs `main.py`.
+- **Windows:** run `UpdateBalanceSheet.bat` — it starts `main.py` and the IB Client Portal gateway in separate windows; log in to the gateway at https://localhost:5000 when it opens.
+- **Directly:** with the IB gateway already running and authenticated, run `python main.py`.
+
+On the **first** run, Questrade prompts you to paste a refresh token (see the Questrade section above); it is saved to `qt_refresh_token.txt` and reused automatically afterward.
 
 ### This is an example of the spreadsheet i'm updating with this script
 

--- a/README.md
+++ b/README.md
@@ -68,13 +68,16 @@ set `ENABLE_WEALTHSIMPLE = False` in your `secrets.py` to skip it on that machin
 
 ### Running the script
 
-With the brokerage setup above complete:
+The portable way to run it on any OS:
 
-- **macOS:** run `./update_balance_sheet.sh` — it opens the IB Client Portal gateway in a new terminal, waits for you to log in at https://localhost:5001, then runs `main.py`.
-- **Windows:** run `UpdateBalanceSheet.bat` — it starts `main.py` and the IB Client Portal gateway in separate windows; log in to the gateway at https://localhost:5000 when it opens.
-- **Directly:** with the IB gateway already running and authenticated, run `python main.py`.
+1. Start the IB Client Portal gateway and **log in / authenticate** it (see the Interactive Brokers section). `main.py` calls IB immediately with no auth wait, so the gateway must be authenticated *before* you run the script, or it will error out.
+2. Activate your venv and run `python main.py`.
 
 On the **first** run, Questrade prompts you to paste a refresh token (see the Questrade section above); it is saved to `qt_refresh_token.txt` and reused automatically afterward.
+
+> The repo also ships the maintainer's personal launcher scripts. They **hard-code local paths** (repo location, gateway folder name, Windows username), so edit them to match your own environment before use:
+> - `update_balance_sheet.sh` (macOS): opens the gateway in a new terminal, waits for you to authenticate at https://localhost:5001, then runs `main.py`.
+> - `UpdateBalanceSheet.bat` (Windows): opens the gateway and `main.py` in separate windows. It does **not** wait for authentication, so make sure the gateway is logged in at https://localhost:5000 before `main.py` reaches it (simplest: just run `python main.py` yourself once the gateway is authenticated).
 
 ### This is an example of the spreadsheet i'm updating with this script
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ Wealthsimple fetching is **enabled by default**. If you don't use Wealthsimple,
 set `ENABLE_WEALTHSIMPLE = False` in your `secrets.py` to skip it on that machine
 (no need to touch `main.py` or maintain a separate branch).
 
+### Spreadsheet Setup
+
+The script writes balances into an **existing** Excel workbook — set its path in `secrets.py` (these are required; with the empty example defaults the run fails when it tries to open the file):
+
+- `ACCOUNT_BALANCE_EXCEL_PATH_MACOS` — used on macOS
+- `ACCOUNT_BALANCE_EXCEL_PATH_WINDOWS` — used on Windows
+
+The workbook must contain a sheet named **`Balances`** with account names in **column A** (from row 2 down) that match the labels the script generates — e.g. `QT (TFSA)`, `IBKR (CASH)`, `IBKR (RRSP)`, `WST (TFSA)`. For each match it writes the balance, date, and time into the columns immediately to the right.
+
+- Column A is the Account_Name
+- Column B is the Account_Balance
+
+![image](https://github.com/0xDario/UpdateBalanceSheet/assets/61662791/b3522b87-e75b-45d6-a738-c4b4a288e667)
+
 ### Running the script
 
 The portable way to run it on any OS:
@@ -78,10 +92,3 @@ On the **first** run, Questrade prompts you to paste a refresh token (see the Qu
 > The repo also ships the maintainer's personal launcher scripts. They **hard-code local paths** (repo location, gateway folder name, Windows username), so edit them to match your own environment before use:
 > - `update_balance_sheet.sh` (macOS): opens the gateway in a new terminal, waits for you to authenticate at https://localhost:5001, then runs `main.py`.
 > - `UpdateBalanceSheet.bat` (Windows): opens the gateway and `main.py` in separate windows. It does **not** wait for authentication, so make sure the gateway is logged in at https://localhost:5000 before `main.py` reaches it (simplest: just run `python main.py` yourself once the gateway is authenticated).
-
-### This is an example of the spreadsheet i'm updating with this script
-
-- Column A is the Account_Name
-- Column B is the Account_Balance
-
-![image](https://github.com/0xDario/UpdateBalanceSheet/assets/61662791/b3522b87-e75b-45d6-a738-c4b4a288e667)


### PR DESCRIPTION
## Why

Following the Questrade refresh-token work (#2) and the Wealthsimple toggle (#3), the README's **Questrade** and **Wealthsimple** sections are already current — they were updated in those PRs. This PR fills the remaining connective gaps so the docs match the current setup end to end.

## Changes

- **Setup:** add a "copy `secrets.example.py` to `secrets.py`" step under *How To Run* (previously every section said "set variables in secrets.py" but nothing told you to create it). Points to the optional settings we added: `ENABLE_WEALTHSIMPLE`, `QT_TOKEN_URL`, `QT_REFRESH_TOKEN_PATH`.
- **Running the script:** new section covering the macOS launcher (`update_balance_sheet.sh`), the Windows launcher (`UpdateBalanceSheet.bat`), running `python main.py` directly, and the first-run Questrade refresh-token prompt.
- **Fix:** Interactive Brokers setup had two `3.` steps — renumbered to 1–7.

## Not changed

- Questrade and Wealthsimple sections — already accurate from #2/#3.
- No code changes; docs only.